### PR TITLE
Fix return type to be non-void for sendTLATE

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 
 The ESP8266 is a low-cost WiFi module built by Espressif Systems. Its popularity has been growing among the hardware community thanks to it’s nice features and stability, to the point that it can be easily programmed using your Arduino IDE.
 
-## Requiremets
+## Requirements
 
 * [An ESP8266 module](https://www.sparkfun.com/products/13678).
 * [An Arduino UNO](https://www.arduino.cc/en/Main/ArduinoBoardUno), [UartSBee](http://www.seeedstudio.com/wiki/UartSBee_V4) or any Uart to USB device.

--- a/UbidotsMicroESP8266.cpp
+++ b/UbidotsMicroESP8266.cpp
@@ -364,7 +364,7 @@ void Ubidots::add(char *variable_id, float value, char *ctext, unsigned long tim
 
 /**
  * Send all data of all variables that you saved
- * @reutrn true upon success, false upon error.
+ * @return true (always)
  */
 bool Ubidots::sendAll(bool type) {
   if (type) {
@@ -421,6 +421,8 @@ bool Ubidots::sendTLATE() {
     Serial.write(c);
   }
   free(data);
+
+  return true;
 }
 
 bool Ubidots::sendHTTP() {


### PR DESCRIPTION
Fix for #28 .

Note that both sub-functions of `sendAll()` retrun true, always. Therefor the `sendAll()` @return is now updated to state:

```
/**
 * Send all data of all variables that you saved
 * @return true (always)
 */
bool Ubidots::sendAll(bool type) {
```
Updating the implementation to return both true and false means adjusting the design of the sub-functions. This is, in my opinion, up to the Ubidots developers to do so.